### PR TITLE
Arregla que nunca carga los programas porque no encuentra una imagan!!.

### DIFF
--- a/carga.py
+++ b/carga.py
@@ -132,7 +132,7 @@ class Cargador(threading.Thread):
             self.win.set_resizable(False)
             self.win.set_default_size(600, 600)
             box1 = gtk.VBox(False, 3)
-            pixbufanim = gtk.gdk.PixbufAnimation("imagenes/gif/icr.gif")
+            pixbufanim = gtk.gdk.PixbufAnimation(sys.path[0]+"imagenes/gif/icr.gif")
             image = gtk.Image()
             image.set_from_animation(pixbufanim)
             image.show()


### PR DESCRIPTION
Hola Valentin,

Estoy trabajando en Huayra y como te dijo @hectorsanchez estamos cerrando la versión 3. y estamos probando Icaro. Teníamos problemas con sdcc pero conseguimos empaquetarlo correctamente, y ahora los ejemplos compilan correctamente, pero al momento de cargarlo a la placa nunca abre el dialogo de carga porque no encuentra la imagen. (Estaba usando rutas relativas.)

Aplicando el parche el dialogo funciona bien, e informa que se cargo correctamente.. pero no conseguimos hacer funcionar la placa... Alguna idea de como comprobar la placa o si hacemos algo mal? Ahora te adjunto la salida del programa.

Este bug en si es una boludez, pero te hago el pull request asi estamos al tanto con cualquier cambio que hacemos.

Saludos!.
Matias. :wink: 
